### PR TITLE
Adding dbox metadata <remote_path>

### DIFF
--- a/bin/dbox
+++ b/bin/dbox
@@ -89,6 +89,10 @@ when "delete"
   local_path = args[1] || remote_path.split("/").last
 
   Dbox.send(command, remote_path, local_path)
+when "metadata"
+  remote_path = args[0]
+  res = Dbox.metadata(remote_path)
+  puts res.inspect
 else
   print_usage_and_quit
 end

--- a/lib/dbox.rb
+++ b/lib/dbox.rb
@@ -95,6 +95,12 @@ module Dbox
     end
   end
 
+  def self.metadata(remote_path)
+    log.debug "Getting metadata for #{remote_path}"
+    remote_path = clean_remote_path(remote_path)
+    Dbox::Syncer.api.metadata(remote_path)
+  end
+
   private
 
   def self.clean_remote_path(path)


### PR DESCRIPTION
Hey Ken,

I needed to get the metadata on the directories in staging so I could delete old directories. Here's a pull request for the changes.

Example code using it:

```
metadata = Dbox.metadata("staging_book_repos")

to_delete = metadata["contents"].select do |data|
  DateTime.parse(data["modified"]) + 7 < DateTime.now
end.map do |data|
  data['path']
end

to_delete.each do |path|
  puts "deleting #{path}"
  Dbox.delete(path)
end
```
